### PR TITLE
feat: 파일변환, 소리분류, 음성전사, 타이틀 생성

### DIFF
--- a/Audiolog/Audiolog/Sources/AudiologView.swift
+++ b/Audiolog/Audiolog/Sources/AudiologView.swift
@@ -71,10 +71,6 @@ struct AudiologView: View {
         }
     }
 
-    private func pendingRecordings() -> [Recording] {
-        recordings.filter { !$0.isTitleGenerated || $0.title.isEmpty }
-    }
-
     @MainActor
     private func reprocessPendingTitlesIfNeeded() async {
         guard !isReprocessingPending else { return }
@@ -100,5 +96,9 @@ struct AudiologView: View {
             await processor.processAudio(for: rec, modelContext: modelContext)
         }
         logger.log("[AudiologView] Reprocess done.")
+    }
+    
+    private func pendingRecordings() -> [Recording] {
+        recordings.filter { !$0.isTitleGenerated || $0.title.isEmpty }
     }
 }

--- a/Audiolog/Audiolog/Sources/Entities/Recording.swift
+++ b/Audiolog/Audiolog/Sources/Entities/Recording.swift
@@ -55,4 +55,8 @@ extension Recording {
         let seconds = Int(duration) % 60
         return String(format: "%d:%02d", minutes, seconds)
     }
+
+    var displayTitle: String {
+        (isTitleGenerated && !title.isEmpty) ? title : "제목 생성중"
+    }
 }

--- a/Audiolog/Audiolog/Sources/Entities/Recording.swift
+++ b/Audiolog/Audiolog/Sources/Entities/Recording.swift
@@ -55,8 +55,4 @@ extension Recording {
         let seconds = Int(duration) % 60
         return String(format: "%d:%02d", minutes, seconds)
     }
-
-    var displayTitle: String {
-        (isTitleGenerated && !title.isEmpty) ? title : "제목 생성중"
-    }
 }

--- a/Audiolog/Audiolog/Sources/Helpers/TitleGuide.swift
+++ b/Audiolog/Audiolog/Sources/Helpers/TitleGuide.swift
@@ -1,0 +1,512 @@
+//
+//  TitleGuide.swift
+//  Audiolog
+//
+//  Created by 성현 on 11/9/25.
+//
+
+import Foundation
+import FoundationModels
+
+// MARK: - Public API
+
+enum TitleGuide {
+    @MainActor
+    static func generateTitle(
+        for recording: Recording,
+        using session: LanguageModelSession,
+        temperature: Double = 0.35,
+        tagWeights: [String: Int]? = nil,
+        policy: TitlePolicy
+    ) async -> String? {
+
+        let ctxObj = TitleContext(recording: recording, weights: tagWeights)
+        let ctxJSON = ctxObj.toJSON()
+
+        let prompt = buildPromptWithPolicy(
+            contextJSON: ctxJSON,
+            policy: policy,
+            hasWalkingCues: ctxObj.hasWalkingCues,
+            primaryTag: ctxObj.primaryTag ?? ""
+        )
+
+        var candidates: [String] = []
+        let N = 4
+        let opts = GenerationOptions(temperature: temperature)
+
+        for _ in 0..<N {
+            do {
+                let res = try await session.respond(options: opts) {
+                    Prompt(prompt)
+                }
+                let t = res.content.trimmingCharacters(
+                    in: .whitespacesAndNewlines
+                )
+                if !t.isEmpty, !t.contains("\n") {
+                    candidates.append(t)
+                }
+
+            } catch {
+                let msg = error.localizedDescription.lowercased()
+                if msg.contains("unsupported language")
+                    || msg.contains("language")
+                {
+                    let fallback = """
+                        한국어 한 문장 제목만 출력하세요. 따옴표/이모지/해시태그 금지.
+                        입력:
+                        \(ctxJSON)
+                        출력: 한국어 한 문장.
+                        """
+                }
+            }
+        }
+
+        guard !candidates.isEmpty else { return nil }
+
+        let scored =
+            candidates
+            .map {
+                (
+                    title: $0,
+                    score: score(title: $0, ctx: ctxObj, policy: policy)
+                )
+            }
+            .sorted { $0.score > $1.score }
+
+        return scored.first?.title
+    }
+}
+
+// MARK: - Generated schema
+
+@Generable
+struct GuidedTitle {
+    @Guide(description: "한국어 한 문장 제목만 출력. 줄바꿈/따옴표/이모지/해시태그/라벨 금지.")
+    var title: String
+}
+
+// MARK: - Context (ko-keys)
+
+private struct TitleContext: Encodable {
+    let primaryTag: String?
+    let secondaryTag: String?
+    let hintTags: [String]
+    let tagWeights: [String: Int]?
+    let location: String?
+    let dialog: String?
+    let bgmTitle: String?
+    let bgmArtist: String?
+
+    let ratios: [String: Double]
+    let primaryRatio: Double
+    let speechRatio: Double
+
+    let hasVoice: Bool
+    let hasWaterAllowed: Bool
+    let hasLocation: Bool
+    let hasWalkingCues: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case primaryTag = "주태그"
+        case secondaryTag = "부태그"
+        case hintTags = "힌트태그"
+        case tagWeights = "태그가중치"
+        case location = "위치"
+        case dialog = "전사"
+        case bgmTitle = "배경음악제목"
+        case bgmArtist = "배경음악아티스트"
+        case ratios = "태그비율"
+        case primaryRatio = "주태그비율"
+        case speechRatio = "음성비율"
+        case hasVoice = "음성유무"
+        case hasWaterAllowed = "물/파도허용"
+        case hasLocation = "위치제공됨"
+    }
+
+    init(recording: Recording, weights: [String: Int]?) {
+        self.tagWeights = weights
+
+        let ordered: [String]
+        let ratiosDict: [String: Double]
+        if let w = weights, !w.isEmpty {
+            let total = max(1, w.values.reduce(0, +))
+            ratiosDict = w.mapValues { Double($0) / Double(total) }
+            ordered = w.sorted { ($0.value, $0.key) > ($1.value, $1.key) }.map {
+                $0.key
+            }
+        } else {
+            ordered = (recording.tags ?? [])
+            ratiosDict = [:]
+        }
+        self.ratios = ratiosDict
+
+        primaryTag = ordered.first
+        secondaryTag = ordered.dropFirst().first
+        hintTags = Array(ordered.dropFirst(2).prefix(3))
+
+        if let raw = recording.dialog?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ), !raw.isEmpty {
+            dialog = raw.split(separator: "\n").prefix(3).joined(separator: " ")
+        } else {
+            dialog = nil
+        }
+
+        location = recording.location
+        bgmTitle = recording.bgmTitle
+        bgmArtist = recording.bgmArtist
+
+        func ratio(for containsKeys: [String]) -> Double {
+            guard !ratiosDict.isEmpty else { return 0 }
+            let keys = ratiosDict.keys.map { $0.lowercased() }
+            var r: Double = 0
+            for (k, v) in ratiosDict {
+                let lk = k.lowercased()
+                if containsKeys.contains(where: { lk.contains($0) }) {
+                    r = max(r, v)
+                }
+            }
+            return r
+        }
+
+        primaryRatio = (primaryTag.flatMap { ratiosDict[$0] } ?? 0)
+        speechRatio = ratio(for: ["speech", "vocal", "singing"])
+
+        hasVoice = speechRatio >= 0.25
+
+        hasWaterAllowed =
+            ratio(for: ["waves", "wave", "water", "ocean", "sea"]) >= 0.15
+
+        hasWalkingCues =
+            ratio(for: ["footsteps", "walking", "walk", "jog", "stroll"])
+            >= 0.15
+
+        hasLocation = (recording.location?.isEmpty == false)
+    }
+
+    func toJSON() -> String {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.withoutEscapingSlashes]
+        return (try? String(data: enc.encode(self), encoding: .utf8)) ?? "{}"
+    }
+}
+
+// MARK: - Policy Model
+
+struct TitlePolicy: Codable {
+    let policyVersion: String
+    let lang: String
+    let guardrails: [String]
+    let priorityRules: PriorityRules
+    let walkingConstraints: WalkingConstraints
+    let speechBias: SpeechBias
+    let specialCases: [SpecialCase]
+    let fewShots: [FewShot]
+
+    struct PriorityRules: Codable {
+        let usePrimaryTagAsMainConcept: Bool
+        let useSecondaryTagAsHint: Bool
+        let useHintTagsAsMoodOnly: Bool
+        let banNewContextFromHintTags: Bool
+    }
+    struct WalkingConstraints: Codable {
+        let requireWalkingCuesForWalkWords: Bool
+        let walkWords: [String]
+    }
+    struct SpeechBias: Codable { let enableWhenPrimaryTagEquals: [String] }
+
+    struct SpecialCase: Codable {
+        let when: String
+        let title: String?
+        let titleWithName: String?
+        let contains: [String]?
+        let titleIfContains: [String: String]?
+        let patterns: [String]?
+        let titlesByTransport: [String: String]?
+        let fallback: String?
+        let titleTalk: String?
+        let titleAmbient: String?
+        let titleTopic: String?
+        let titleMonologue: String?
+        let mapByDialog: [String: String]?
+        let scheduleKeywords: [String]?
+        let titleSchedule: String?
+        let titleScheduleWithName: String?
+        let titleMeta: String?
+        let titleTitleOnly: String?
+    }
+
+    struct FewShot: Codable {
+        let input: [String: String?]
+        let output: String
+    }
+}
+
+// MARK: - Policy Loader (Bundle 전용 + 최소 fallback)
+
+private enum TitlePolicyLoader {
+    static func load() -> TitlePolicy {
+        guard
+            let url = Bundle.main.url(
+                forResource: "TitlePolicy",
+                withExtension: "json"
+            )
+        else {
+            #if DEBUG
+                assertionFailure(
+                    "[TitlePolicy] TitlePolicy.json not found in bundle. Check filename/target membership/Copy Bundle Resources."
+                )
+            #endif
+            fatalError("[TitlePolicy] TitlePolicy.json not found in bundle.")
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let obj = try JSONDecoder().decode(TitlePolicy.self, from: data)
+            return obj
+        } catch {
+            #if DEBUG
+                assertionFailure(
+                    "[TitlePolicy] Failed to decode TitlePolicy.json: \(error)"
+                )
+            #endif
+            fatalError(
+                "[TitlePolicy] Failed to decode TitlePolicy.json: \(error)"
+            )
+        }
+    }
+}
+
+// MARK: - Prompt Builder (Policy → ICL few-shot)
+
+private func buildPromptWithPolicy(
+    contextJSON: String,
+    policy: TitlePolicy,
+    hasWalkingCues: Bool,
+    primaryTag: String
+) -> String {
+
+    let guardrails = policy.guardrails.map { "• \($0) (권장)" }.joined(
+        separator: "\n"
+    )
+    let shots = makeFewShots(from: policy)
+    let shotBlock = shots.map { "입력: \($0.inputJSON)\n출력: \($0.output)" }
+        .joined(separator: "\n\n")
+
+    // 🔹 금지 규칙(하드 가드)
+    let hardBans = """
+        금지 규칙(MUST NOT):
+        - 입력 JSON에 '위치'가 없으면 지명/장소(예: 부산, 해운대, 서울, 카페 등)를 절대 쓰지 말 것.
+        - 입력 JSON에 '음성유무'가 false면 '대화/회의/인터뷰/혼잣말' 등 말 관련 단어를 절대 쓰지 말 것.
+        - 입력 JSON에 '물/파도허용'이 false면 '파도/바다/해변' 관련 단어를 절대 쓰지 말 것.
+        - 입력에 없는 인명/행사명/지명/노래제목/가수 등을 절대 창작하지 말 것.
+        - 태그 비중이 12% 미만인 항목의 단어를 제목에 직접 쓰지 말 것(분위기 힌트는 가능).
+        """
+
+    let walkLine =
+        hasWalkingCues
+        ? "- ‘산책’ 표현 사용 가능(보행 단서 충분)."
+        : "- ‘산책’ 금지(보행 단서 부족). ‘대화/소리’ 등으로 표현."
+    let speechBias =
+        policy.speechBias.enableWhenPrimaryTagEquals.contains {
+            primaryTag.lowercased().contains($0.lowercased())
+        }
+        ? "- 주태그가 ‘speech’이면, 음성비율이 충분할 때(≥20~25%) 제목을 대화/회의/인터뷰 축으로 유도."
+        : ""
+
+    // 비중 기반 작문 원칙(모델에 수치 감각 심어주기)
+    let ratioPrinciples = """
+        비중(태그비율) 원칙:
+        - 주태그 비율이 35% 이상이면, 그 주태그를 제목의 핵심 콘셉트로 **반드시** 반영.
+        - 20~35% 구간은 가급적 반영하되, 다른 신호(전사/위치/특수케이스)와 조화롭게 선택.
+        - 12% 미만인 태그는 단어를 직접 쓰지 말고, 분위기 힌트로만 사용.
+        """
+
+    return """
+        모든 입출력은 한국어(ko-KR)로 작성합니다.
+
+        제목 작성 지향(소프트 가이드):
+        \(guardrails)
+
+        \(hardBans)
+
+        \(ratioPrinciples)
+
+        태그 우선순위(권장):
+        - 주태그(primary)가 제목의 핵심 콘셉트가 되도록 지향.
+        - 부태그/힌트태그는 분위기 보조. 힌트로 새로운 맥락 생성 금지.
+        \(walkLine)
+        \(speechBias)
+
+        예시(Few-shot, 참고용):
+        \(shotBlock)
+
+        입력(JSON):
+        \(contextJSON)
+
+        위 지향과 금지 규칙을 모두 준수하여 자연스럽고 간결한 **한국어 한 문장** 제목만 출력하세요.
+        따옴표/이모지/해시태그/접두 라벨/줄바꿈 금지.
+        """
+}
+
+private func makeFewShots(from policy: TitlePolicy) -> [(
+    inputJSON: String, output: String
+)] {
+    var items: [(String, String)] = []
+
+    // 1) 정책에 명시된 fewShots 우선 (nil 값 제거하여 직렬화)
+    for fs in policy.fewShots {
+        var dict: [String: Any] = [:]
+        for (k, v) in fs.input {
+            if let value = v { dict[k] = value }
+        }
+        if let data = try? JSONSerialization.data(
+            withJSONObject: dict,
+            options: []
+        ),
+            let json = String(data: data, encoding: .utf8)
+        {
+            items.append((json, fs.output))
+        }
+    }
+
+    // 2) specialCases도 간단 대표 예시로 변환 (너무 많아지지 않게 최소화)
+    for sc in policy.specialCases {
+        switch sc.when {
+        case "interview":
+            if let out = sc.title {
+                items.append((#"{"주태그":"speech","전사":"자기소개 부탁드립니다"}"#, out))
+            }
+            if let withName = sc.titleWithName {
+                let o = withName.replacingOccurrences(of: "{name}", with: "민수")
+                items.append((#"{"주태그":"speech","전사":"민수 씨, 인터뷰 시작하겠습니다"}"#, o))
+            }
+        case "waves":
+            if let t = sc.titleTalk {
+                items.append(
+                    (#"{"주태그":"waves","부태그":"speech","전사":"사진 한 장 더 찍자"}"#, t)
+                )
+            }
+            if let a = sc.titleAmbient {
+                items.append((#"{"주태그":"waves"}"#, a))
+            }
+        case "musicDominant":
+            if let meta = sc.titleMeta {
+                let o =
+                    meta
+                    .replacingOccurrences(of: "{bgmTitle}", with: "Lo-fi beats")
+                    .replacingOccurrences(of: "{bgmArtist}", with: "Playlist")
+                items.append(
+                    (
+                        #"{"주태그":"music","부태그":"singing","배경음악제목":"Lo-fi beats","배경음악아티스트":"Playlist"}"#,
+                        o
+                    )
+                )
+            }
+            if let fb = sc.fallback {
+                items.append((#"{"주태그":"music"}"#, fb))
+            }
+        default:
+            break
+        }
+    }
+
+    items.shuffle()
+    return Array(items.prefix(12))
+}
+
+// MARK: - Soft Reranking
+
+private func score(title: String, ctx: TitleContext, policy: TitlePolicy)
+    -> Double
+{
+    var s = 0.0
+    let t = title
+
+    // ratio helper
+    func ratio(for keys: [String]) -> Double {
+        guard !ctx.ratios.isEmpty else { return 0 }
+        var r = 0.0
+        for (k, v) in ctx.ratios {
+            let lk = k.lowercased()
+            if keys.contains(where: { lk.contains($0) }) {
+                r = max(r, v)
+            }
+        }
+        return r
+    }
+
+    let rSpeech = ctx.speechRatio
+    let rWaves = ratio(for: ["waves", "wave", "water", "ocean", "sea"])
+    let rMusic = ratio(for: [
+        "music", "singing", "keyboard", "guitar", "piano", "instrument",
+    ])
+    let rRain = ratio(for: ["rain"])
+    let rSiren = ratio(for: ["siren", "alarm", "beep"])
+
+    // 1) 주태그/비중 기반 가점
+    if let p = ctx.primaryTag?.lowercased() {
+        // speech 계열
+        if t.contains("대화") || t.contains("회의") || t.contains("인터뷰") {
+            // speechRatio에 비례한 가점 (최대 +3.0)
+            s += min(3.0, 4.0 * rSpeech)
+            if p.contains("speech") { s += 0.8 }  // 주태그가 speech면 추가 가점
+        }
+        // music 계열
+        if t.contains("음악") || t.contains("연주") {
+            s += min(2.2, 3.0 * rMusic)
+            if p.contains("music") { s += 0.6 }
+        }
+        // rain / waves / siren
+        if t.contains("빗") { s += min(1.8, 2.5 * rRain) }
+        if t.contains("파도") { s += min(1.8, 2.5 * rWaves) }
+        if t.contains("사이렌") || t.contains("경보") { s += min(1.6, 2.0 * rSiren) }
+    }
+
+    // 2) 금지/불일치 감점
+    if !ctx.hasVoice
+        && (t.contains("대화") || t.contains("회의") || t.contains("인터뷰")
+            || t.contains("혼잣말"))
+    {
+        s -= 5.0
+    }
+    if !ctx.hasWaterAllowed
+        && (t.contains("파도") || t.contains("바다") || t.contains("해변"))
+    {
+        s -= 4.0
+    }
+    if !ctx.hasLocation && containsPlaceLikeWord(t) {
+        s -= 5.0
+    }
+    // waves 단어인데 비중이 너무 낮음(12% 미만) → 추가 감점
+    if (t.contains("파도") || t.contains("바다") || t.contains("해변"))
+        && rWaves < 0.12
+    {
+        s -= 2.5
+    }
+    // 음악/연주인데 music 비중이 매우 낮음(12% 미만) → 추가 감점
+    if (t.contains("음악") || t.contains("연주")) && rMusic < 0.12 {
+        s -= 2.0
+    }
+    // ‘산책’ 단어인데 보행 단서 없음 → 강력 감점
+    if (t.contains("산책") || t.contains("걷") || t.contains("발걸음")
+        || t.contains("조깅")) && !ctx.hasWalkingCues
+    {
+        s -= 4.0
+    }
+
+    // 3) 형식/길이 보너스
+    if !t.contains("  ") && t.count <= 22 { s += 0.5 }
+    if !["\"", "“", "#", "…"].contains(where: t.contains) { s += 0.3 }
+
+    return s
+}
+
+private func containsPlaceLikeWord(_ t: String) -> Bool {
+    // 아주 간단한 휴리스틱: 흔한 지명/장소 표기
+    let words = [
+        "서울", "부산", "해운대", "강남", "종로", "카페", "역", "광장", "공원", "교회", "연습실",
+        "스튜디오", "해변", "바다",
+    ]
+    return words.contains { t.contains($0) }
+}

--- a/Audiolog/Audiolog/Sources/Helpers/TitlePolicy.json
+++ b/Audiolog/Audiolog/Sources/Helpers/TitlePolicy.json
@@ -1,0 +1,193 @@
+{
+    "policyVersion": "2025-11-10T01:50:00Z",
+    "lang": "ko-KR",
+    "guardrails": [
+        "반드시 한국어 한 문장으로만 출력",
+        "따옴표/이모지/해시태그/접두 라벨 금지",
+        "입력에 없는 사실 추정 금지",
+        "정시/분 표기 금지(계절·대략적 시간대만 유추)"
+    ],
+    "priorityRules": {
+        "usePrimaryTagAsMainConcept": true,
+        "useSecondaryTagAsHint": true,
+        "useHintTagsAsMoodOnly": true,
+        "banNewContextFromHintTags": true
+    },
+    "walkingConstraints": {
+        "requireWalkingCuesForWalkWords": true,
+        "walkWords": [
+            "산책",
+            "걷",
+            "발걸음",
+            "조깅"
+        ]
+    },
+    "speechBias": {
+        "enableWhenPrimaryTagEquals": [
+            "speech"
+        ]
+    },
+    "specialCases": [
+        {
+            "when": "interview",
+            "title": "인터뷰 녹음",
+            "titleWithName": "{name}과 인터뷰"
+        },
+        {
+            "when": "meeting",
+            "contains": [
+                "회의",
+                "스프린트",
+                "일정",
+                "안건",
+                "아젠다",
+                "리뷰",
+                "레트로"
+            ],
+            "title": "팀 회의",
+            "titleIfContains": {
+                "스프린트": "스프린트 목표 회의"
+            }
+        },
+        {
+            "when": "broadcast",
+            "patterns": [
+                "이번 역은",
+                "환승",
+                "내려 주시기"
+            ],
+            "titlesByTransport": {
+                "지하철": "지하철 안내방송",
+                "버스": "버스 안내방송",
+                "기차": "기차 안내방송"
+            },
+            "fallback": "대중교통 안내방송"
+        },
+        {
+            "when": "sermon",
+            "keywords": [
+                "설교",
+                "본문",
+                "아멘",
+                "예배"
+            ],
+            "title": "설교",
+            "titleWithVerse": "{verse} 설교"
+        },
+        {
+            "when": "waves",
+            "titleTalk": "파도소리 속 대화",
+            "titleAmbient": "파도소리"
+        },
+        {
+            "when": "rain",
+            "titleTopic": "빗소리 속 {topic}",
+            "titleMonologue": "빗소리 속 혼잣말"
+        },
+        {
+            "when": "birds",
+            "title": "예쁜 새소리"
+        },
+        {
+            "when": "mechanical",
+            "title": "기계소리"
+        },
+        {
+            "when": "event",
+            "title": "행사 속 환호",
+            "titleWithName": "{event} 속 환호"
+        },
+        {
+            "when": "sports",
+            "title": "경기장 골 함성"
+        },
+        {
+            "when": "siren",
+            "mapByDialog": {
+                "소방": "소방 사이렌",
+                "fire": "소방 사이렌",
+                "구급": "구급차 사이렌",
+                "ambulance": "구급차 사이렌",
+                "대피": "재난 대피 경보",
+                "재난": "재난 대피 경보"
+            },
+            "fallback": "경보음"
+        },
+        {
+            "when": "cafeTalk",
+            "scheduleKeywords": [
+                "예약",
+                "몇 시",
+                "오전",
+                "오후",
+                "가능해",
+                "일정",
+                "캘린더",
+                "회의실"
+            ],
+            "title": "카페의 대화",
+            "titleSchedule": "일정 정하는 대화",
+            "titleScheduleWithName": "{name}과 일정 계획"
+        },
+        {
+            "when": "carTalk",
+            "title": "이동 중 대화",
+            "titleWithName": "{name}과 이동 중 대화"
+        },
+        {
+            "when": "musicDominant",
+            "titleMeta": "{bgmTitle}, {bgmArtist}",
+            "titleTitleOnly": "{bgmTitle}",
+            "fallback": "음악 속의 대화"
+        },
+        {
+            "when": "genericSpeech",
+            "title": "대화",
+            "titleWithName": "{name}과 대화"
+        }
+    ],
+    "fewShots": [
+        {
+            "input": {
+                "주태그": "waves",
+                "부태그": "speech",
+                "위치": "부산 해운대",
+                "전사": "사진 한 장 더 찍자"
+            },
+            "output": "파도소리 속 대화"
+        },
+        {
+            "input": {
+                "주태그": "traffic",
+                "부태그": "speech",
+                "전사": "부산까지 4시간쯤?"
+            },
+            "output": "이동 중 대화"
+        },
+        {
+            "input": {
+                "주태그": "speech",
+                "위치": "서울 강남 카페",
+                "전사": "내일 3시에 가능해?"
+            },
+            "output": "일정 정하는 대화"
+        },
+        {
+            "input": {
+                "주태그": "rain",
+                "부태그": "speech",
+                "전사": "오늘은 일찍 자야지"
+            },
+            "output": "빗소리 속 혼잣말"
+        },
+        {
+            "input": {
+                "주태그": "music",
+                "부태그": "singing",
+                "배경음악제목": "로파이 비트",
+                "배경음악아티스트": "재생목록"
+            },
+            "output": "로파이 비트, 재생목록"
+        }
+    ]
+}

--- a/Audiolog/Audiolog/Sources/Models/AudioProcesser.swift
+++ b/Audiolog/Audiolog/Sources/Models/AudioProcesser.swift
@@ -1,0 +1,547 @@
+//
+//  AudioProcesser.swift
+//  Audiolog
+//
+//  Created by 성현 on 11/6/25.
+//
+
+import AVFoundation
+import Foundation
+import FoundationModels
+import Playgrounds
+import SoundAnalysis
+import Speech
+import SwiftData
+import UniformTypeIdentifiers
+
+@Observable
+class AudioProcesser: NSObject {
+    // 모델 세션 (Title 생성에 사용)
+    private var session: LanguageModelSession
+    private let titlePolicy: TitlePolicy
+
+    override init() {
+        self.session = LanguageModelSession()
+        self.titlePolicy = AudioProcesser.loadTitlePolicyOnce()
+        super.init()
+    }
+
+    // 내부 상태
+    private var analyzerRef: SNAudioFileAnalyzer?
+    private var observerRef: ClassificationObserver?
+
+    private static func loadTitlePolicyOnce() -> TitlePolicy {
+        guard
+            let url = Bundle.main.url(
+                forResource: "TitlePolicy",
+                withExtension: "json"
+            )
+        else {
+            fatalError("[TitlePolicy] TitlePolicy.json not found in bundle")
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(TitlePolicy.self, from: data)
+        } catch {
+            fatalError("[TitlePolicy] Failed to decode: \(error)")
+        }
+    }
+
+    // MARK: - Public entrypoint
+    @MainActor
+    func processAudio(for recording: Recording, modelContext: ModelContext)
+        async
+    {
+        logStep(
+            0,
+            "processAudio 시작",
+            [
+                "recordingId": recording.id.uuidString,
+                "fileURL": recording.fileURL.absoluteString,
+                "duration": String(format: "%.3f", recording.duration),
+            ]
+        )
+
+        do {
+            // 0) 오디오 세션 최소 설정 (try?는 throw하지 않으므로 do/catch 제거)
+            try? AVAudioSession.sharedInstance().setCategory(
+                .playback,
+                mode: .default
+            )
+            try? AVAudioSession.sharedInstance().setActive(true)
+            logger.log("[AudioProcesser] (0) AVAudioSession OK")
+
+            // 1) 변환/보장
+            logStep(
+                1,
+                "파일 준비(분석 가능 포맷 보장) 시작",
+                ["inputPath": recording.fileURL.path]
+            )
+            let safeURL = try await prepareAudioURL(recording.fileURL)
+            logStep(
+                1,
+                "파일 준비 완료",
+                ["safePath": safeURL.path]
+            )
+
+            // 2) 사운드 분류
+            logStep(2, "사운드 분류 시작", ["url": safeURL.lastPathComponent])
+            let (stats, hasVoice) = try await analyzeSound(url: safeURL)
+
+            let totalCount = stats.values.reduce(0, +)
+
+            let top5Pairs = stats.sorted { $0.value > $1.value }.prefix(5)
+            let top5 = top5Pairs.map { $0.key }
+
+            let top5Ratios = top5Pairs.map { (label, count) -> String in
+                let ratio =
+                    totalCount > 0
+                    ? Double(count) / Double(totalCount) * 100 : 0
+                return String(format: "%@ %.1f%%", label, ratio)
+            }
+
+            recording.tags = top5
+
+            logStep(
+                2,
+                "사운드 분류 완료",
+                [
+                    "top5": top5.joined(separator: ", "),
+                    "ratios": top5Ratios.joined(separator: " | "),
+                    "hasVoice": "\(hasVoice)",
+                    "totalFrames": "\(totalCount)",
+                ]
+            )
+
+            do {
+                try modelContext.save()
+                logger.log("[AudioProcesser] (2.5) 중간 저장 OK")
+            } catch {
+                logNSError(error, prefix: "(2.5) modelContext.save()")
+            }
+
+            // 3) 전사 (스피치/싱잉일 때만)
+            if hasVoice {
+                logStep(3, "전사 시작", ["locale": "ko_KR"])
+                if let transcript = try? await transcribe(
+                    url: safeURL,
+                    localeIdentifier: "ko_KR"
+                ) {
+                    recording.dialog = transcript
+                    logStep(3, "전사 완료", ["length": "\(transcript.count)"])
+                    let preview = transcript.replacingOccurrences(
+                        of: "\n",
+                        with: " "
+                    )
+                    .prefix(120)
+                    logger.log("[AudioProcesser] (3) 전사 미리보기: \(preview)")
+                    try? modelContext.save()
+                } else {
+                    logger.log(
+                        "[AudioProcesser] (3) 전사 스킵 또는 실패(에러는 상단에서 이미 로깅됨)"
+                    )
+                }
+            } else {
+                logger.log("[AudioProcesser] (3) hasVoice=false 전사 스킵")
+            }
+
+            // TODO: music, singing일 때, 샤잠킷 구동하는 부분
+
+            // 4) 타이틀 생성
+            logStep(4, "타이틀 생성 시작(TitleGuide)", [:])
+            if let title = await TitleGuide.generateTitle(
+                for: recording,
+                using: session,
+                temperature: 0.35,
+                tagWeights: stats,  // ⬅️ 한 번만 전달
+                policy: self.titlePolicy  // ⬅️ 주입된 정책 사용
+            ) {
+                recording.title = title
+                recording.isTitleGenerated = true
+                logStep(4, "타이틀 생성 완료", ["title": title])
+            } else {
+                logger.log(
+                    "[AudioProcesser] (4) TitleGuide.generateTitle 실패 (nil)"
+                )
+            }
+
+            // 5) 최종 저장
+            logStep(5, "최종 저장 시작", [:])
+            try modelContext.save()
+            logStep(5, "최종 저장 완료", ["recordingId": recording.id.uuidString])
+
+        } catch {
+            // 실패는 조용히 로깅 수준으로 처리. 필요 시 에러 전달 구조로 확장 가능.
+            let ns = error as NSError
+            logger.log(
+                "[AudioProcesser] ERROR processAudio: \(ns.domain)(\(ns.code)) \(ns.localizedDescription) userInfo=\(ns.userInfo)"
+            )
+        }
+
+        logger.log("[AudioProcesser] processAudio 종료")
+    }
+
+    // MARK: - File preparation (mov/mp4 → m4a 보장)
+    /// 분석 가능한 오디오 URL 보장: 트랙 없으면 에러, 필요 시 M4A로 추출
+    private func prepareAudioURL(_ url: URL) async throws -> URL {
+        logger.log("[AudioProcesser] (1) prepareAudioURL 입력: \(debugURL(url))")
+        let asset = AVURLAsset(url: url)
+
+        // 가용성 로깅 (deprecated 속성 대신 load API 사용)
+        let isReadable: Bool
+        let isExportable: Bool
+        do {
+            isReadable = try await asset.load(.isReadable)
+        } catch {
+            self.logNSError(error, prefix: "(1) load(.isReadable)")
+            throw error
+        }
+        do {
+            isExportable = try await asset.load(.isExportable)
+        } catch {
+            self.logNSError(error, prefix: "(1) load(.isExportable)")
+            throw error
+        }
+        logger.log(
+            "[AudioProcesser] (1) AVURLAsset flags readable=\(isReadable) exportable=\(isExportable)"
+        )
+
+        do {
+            let tracks = try await asset.load(.tracks)
+            let audioTracks = tracks.filter { $0.mediaType == .audio }
+            guard !audioTracks.isEmpty else {
+                logger.log("[AudioProcesser] (1) 오디오 트랙 없음")
+                throw APFailure("해당 파일에 오디오 트랙이 없습니다.")
+            }
+        } catch {
+            logNSError(error, prefix: "(1) load(.tracks)")
+            throw error
+        }
+
+        if url.pathExtension.lowercased() == "m4a" {
+            logger.log("[AudioProcesser] (1) 이미 m4a, 변환 생략")
+            return url
+        }
+
+        do {
+            let out = try await exportToM4A(
+                from: asset,
+                basename: url.deletingPathExtension().lastPathComponent
+            )
+            logger.log("[AudioProcesser] (1) exportToM4A 성공: \(debugURL(out))")
+            return out
+        } catch {
+            logNSError(error, prefix: "(1) exportToM4A")
+            throw error
+        }
+    }
+
+    private func exportToM4A(from asset: AVURLAsset, basename: String)
+        async throws -> URL
+    {
+        guard
+            let export = AVAssetExportSession(
+                asset: asset,
+                presetName: AVAssetExportPresetAppleM4A
+            )
+        else {
+            throw APFailure("오디오 추출 세션 생성 실패")
+        }
+        let out = temporaryM4AURL("\(basename)-ap")
+        export.outputURL = out
+        export.outputFileType = .m4a
+
+        let duration: CMTime
+        do {
+            duration = try await asset.load(.duration)
+        } catch {
+            logNSError(error, prefix: "(1) load(.duration)")
+            throw error
+        }
+        export.timeRange = CMTimeRange(start: .zero, duration: duration)
+
+        logger.log(
+            "[AudioProcesser] (1) AVAssetExport 시작 → \(out.lastPathComponent) duration=\(CMTimeGetSeconds(duration))s"
+        )
+
+        do {
+            try await export.export(to: out, as: .m4a)
+        } catch {
+            logNSError(error, prefix: "(1) AVAssetExport")
+            logger.log(
+                "[AudioProcesser] (1) AVAssetExport FAIL out=\(debugURL(out))"
+            )
+            throw error
+        }
+
+        return out
+    }
+
+    private func temporaryM4AURL(_ basename: String) -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+        let safe = basename.replacingOccurrences(
+            of: "[/:\\?%*|\"<>]",
+            with: "-",
+            options: .regularExpression
+        )
+        return tmp.appendingPathComponent(
+            "\(safe)-\(UUID().uuidString.prefix(6)).m4a"
+        )
+    }
+
+    // MARK: - Sound Analysis
+    private func analyzeSound(url: URL) async throws -> ([String: Int], Bool) {
+        logger.log("[AudioProcesser] (2) analyzeSound 입력: \(debugURL(url))")
+
+        let analyzer: SNAudioFileAnalyzer = try SNAudioFileAnalyzer(url: url)
+        let request: SNClassifySoundRequest = try SNClassifySoundRequest(
+            classifierIdentifier: .version1
+        )
+        request.windowDuration = CMTimeMakeWithSeconds(
+            1.5,
+            preferredTimescale: 44100
+        )
+
+        var collected: [ClassificationItem] = []
+        let cont = AnalysisContinuation()
+        let observer = ClassificationObserver { result, finished in
+            switch result {
+            case .success(let items):
+                collected.append(contentsOf: items)
+            case .failure(let error):
+                self.logNSError(error, prefix: "(2) observer")
+                cont.resumeThrowing(error)
+                return
+            }
+            if finished { cont.resume() }
+        }
+
+        try analyzer.add(request, withObserver: observer)
+        self.analyzerRef = analyzer
+        self.observerRef = observer
+        do {
+            try await analyzer.analyze()
+            observer.finish()
+        } catch { observer.fail(error) }
+        try await cont.wait()
+
+        // 집계
+        var labelStats: [String: Int] = [:]
+        var hasVoice = false
+        for it in collected {
+            labelStats[it.label, default: 0] += 1
+            let l = it.label.lowercased()
+            if (l.contains("speech") || l.contains("singing")
+                || l.contains("vocal")) && it.confidence >= 0.40
+            {
+                hasVoice = true
+            }
+        }
+
+        logger.log(
+            "[AudioProcesser] (2) 집계 결과: totalFrames=\(collected.count) uniqueLabels=\(labelStats.count)"
+        )
+        return (labelStats, hasVoice)
+    }
+
+    // MARK: - Transcription
+    private func transcribe(url: URL, localeIdentifier: String) async throws
+        -> String
+    {
+        logger.log(
+            "[AudioProcesser] (3) transcribe 시작: \(url.lastPathComponent) locale=\(localeIdentifier)"
+        )
+
+        guard
+            let recognizer = SFSpeechRecognizer(
+                locale: Locale(identifier: localeIdentifier)
+            )
+        else {
+            throw APFailure("해당 로케일에서 인식기를 초기화할 수 없음")
+        }
+        guard recognizer.isAvailable else {
+            throw APFailure("지금 인식 서비스 사용 불가")
+        }
+
+        let request = SFSpeechURLRecognitionRequest(url: url)
+        request.shouldReportPartialResults = true
+
+        return try await withCheckedThrowingContinuation {
+            (cont: CheckedContinuation<String, Error>) in
+            var finalText = ""
+            var finished = false
+            let task = recognizer.recognitionTask(with: request) {
+                result,
+                error in
+                if let error {
+                    self.logNSError(error, prefix: "(3) recognitionTask")
+                    guard !finished else { return }
+                    finished = true
+                    cont.resume(throwing: error)
+                    return
+                }
+                guard let result else { return }
+                let raw = result.bestTranscription.formattedString
+                finalText = Self.paragraphized(raw)
+                if result.isFinal {
+                    guard !finished else { return }
+                    finished = true
+                    cont.resume(returning: finalText)
+                }
+            }
+            // 취소 안전
+            Task {
+                await Task.yield()
+                if Task.isCancelled { task.cancel() }
+            }
+        }
+    }
+
+    private static func paragraphized(_ raw: String) -> String {
+        // 간단한 문장부호 기준 줄바꿈
+        return
+            raw
+            .replacingOccurrences(of: "  ", with: " ")
+            .replacingOccurrences(of: ". ", with: ".\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: Music identifier
+    // TODO: 샤잠킷 함수
+
+    // MARK: - Debug helpers
+
+    /// 단계를 번호와 함께 기록
+    private func logStep(_ step: Int, _ title: String, _ info: [String: String])
+    {
+        let kv = info.map { "\($0.key)=\($0.value)" }.joined(separator: " ")
+        logger.log("[AudioProcesser] (\(step)) \(title) \(kv)")
+    }
+
+    /// 에러를 상세하게 기록
+    private func logNSError(_ error: Error, prefix: String) {
+        let ns = error as NSError
+        var msg =
+            "[AudioProcesser] \(prefix) ERROR \(ns.domain)(\(ns.code)) \(ns.localizedDescription)"
+        if let r = ns.localizedFailureReason { msg += " | reason=\(r)" }
+        if let s = ns.localizedRecoverySuggestion {
+            msg += " | suggestion=\(s)"
+        }
+        if !ns.userInfo.isEmpty { msg += " | userInfo=\(ns.userInfo)" }
+        logger.log(msg)
+    }
+
+    /// 파일 경로/존재/사이즈/타임스탬프를 문자열로 요약
+    private func debugURL(_ url: URL) -> String {
+        let fm = FileManager.default
+        var parts: [String] = []
+        parts.append("path=\(url.path)")
+        let exists = fm.fileExists(atPath: url.path)
+        parts.append("exists=\(exists)")
+        if exists, let attrs = try? fm.attributesOfItem(atPath: url.path) {
+            if let size = attrs[.size] as? NSNumber {
+                parts.append("size=\(size.uint64Value)B")
+            }
+            if let cdate = attrs[.creationDate] as? Date {
+                parts.append("created=\(cdate)")
+            }
+            if let mdate = attrs[.modificationDate] as? Date {
+                parts.append("modified=\(mdate)")
+            }
+        }
+        return parts.joined(separator: " ")
+    }
+}
+
+// MARK: - Helper types
+
+struct APFailure: LocalizedError {
+    let message: String
+    init(_ m: String) { message = m }
+    var errorDescription: String? { message }
+}
+
+private struct ClassificationItem {
+    let label: String
+    let confidence: Double
+    let timeRange: CMTimeRange
+}
+
+private final class AnalysisContinuation {
+    private var resumed = false
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    func wait() async throws {
+        try await withCheckedThrowingContinuation {
+            (c: CheckedContinuation<Void, Error>) in
+            if resumed {
+                c.resume()
+            } else {
+                continuation = c
+            }
+        }
+    }
+
+    func resume() {
+        guard !resumed else { return }
+        resumed = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func resumeThrowing(_ error: Error) {
+        guard !resumed else { return }
+        resumed = true
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+}
+
+/// SNResultsObserving 어댑터: 파일 분석 전 구간을 수집하고 종료 시그널을 전달
+private class ClassificationObserver: NSObject, SNResultsObserving {
+    private let handler: (Result<[ClassificationItem], Error>, Bool) -> Void
+    private var finished = false
+
+    init(handler: @escaping (Result<[ClassificationItem], Error>, Bool) -> Void)
+    {
+        self.handler = handler
+    }
+
+    func request(_ request: SNRequest, didProduce result: SNResult) {
+        guard let r = result as? SNClassificationResult else { return }
+        let items: [ClassificationItem] = r.classifications
+            .filter { $0.confidence > 0.20 }
+            .map {
+                ClassificationItem(
+                    label: $0.identifier,
+                    confidence: $0.confidence,
+                    timeRange: r.timeRange
+                )
+            }
+        handler(.success(items), false)
+    }
+
+    func requestDidFail(_ request: SNRequest, withError error: Error) {
+        guard !finished else { return }
+        finished = true
+        handler(.failure(error), true)
+    }
+
+    func requestDidComplete(_ request: SNRequest) {
+        guard !finished else { return }
+        finished = true
+        handler(.success([]), true)
+    }
+
+    func finish() {
+        guard !finished else { return }
+        finished = true
+        handler(.success([]), true)
+    }
+
+    func fail(_ error: Error) {
+        guard !finished else { return }
+        finished = true
+        handler(.failure(error), true)
+    }
+}

--- a/Audiolog/Audiolog/Sources/Models/AudioRecorder.swift
+++ b/Audiolog/Audiolog/Sources/Models/AudioRecorder.swift
@@ -217,7 +217,7 @@ class AudioRecorder: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate,
             self.isRecordForCallBacks = false
             DispatchQueue.main.async {
                 self.isRecording = false
-                self.timeElapsed = 0
+//                self.timeElapsed = 0 -> 끝날때 초 0초되는 현상 제거
                 self.firstBufferPTS = nil
             }
         }

--- a/Audiolog/Audiolog/Sources/Views/ArchiveView.swift
+++ b/Audiolog/Audiolog/Sources/Views/ArchiveView.swift
@@ -32,9 +32,10 @@ struct ArchiveView: View {
                                 .font(.title2)
                                 .foregroundStyle(.blue)
                             VStack(alignment: .leading, spacing: 4) {
-                                Text(item.title)
+                                Text(item.displayTitle)
                                     .font(.headline)
                                     .lineLimit(1)
+                                    .opacity(item.isTitleGenerated ? 1 : 0.6)
                                 HStack(spacing: 8) {
                                     Text(item.formattedDuration)
                                     Text("·")

--- a/Audiolog/Audiolog/Sources/Views/ArchiveView.swift
+++ b/Audiolog/Audiolog/Sources/Views/ArchiveView.swift
@@ -32,10 +32,10 @@ struct ArchiveView: View {
                                 .font(.title2)
                                 .foregroundStyle(.blue)
                             VStack(alignment: .leading, spacing: 4) {
-                                Text(item.displayTitle)
-                                    .font(.headline)
-                                    .lineLimit(1)
-                                    .opacity(item.isTitleGenerated ? 1 : 0.6)
+                                Text(item.isTitleGenerated && !item.title.isEmpty ? item.title : "제목 생성중")
+                                        .font(.headline)
+                                        .lineLimit(1)
+                                        .opacity(item.isTitleGenerated ? 1 : 0.6)
                                 HStack(spacing: 8) {
                                     Text(item.formattedDuration)
                                     Text("·")

--- a/Audiolog/Audiolog/Sources/Views/RecordView.swift
+++ b/Audiolog/Audiolog/Sources/Views/RecordView.swift
@@ -14,7 +14,6 @@ struct RecordView: View {
     @State private var audioRecorder = AudioRecorder()
 
     // TODO: Weather, Location 관련 Manager 모셔오기
-    
     @Environment(\.scenePhase) var scenePhase
     @Environment(\.modelContext) private var modelContext
 
@@ -75,34 +74,39 @@ struct RecordView: View {
     private func stopAndPersistRecordingOnScenePhaseChange() async {
         await audioRecorder.stopRecording()
         logger.log(
-            "[RecordView] Stopped recording due to scenePhase change to \(String(describing: scenePhase)). fileURL=\(String(describing: audioRecorder.fileURL)), elapsed=\(audioRecorder.timeElapsed))"
+            "[RecordView] Stopped recording due to scenePhase=\(String(describing: scenePhase)). " +
+            "fileURL=\(String(describing: audioRecorder.fileURL)), elapsed=\(audioRecorder.timeElapsed)"
         )
-        if let url = audioRecorder.fileURL {
-            logger.log(
-                "[RecordView] Will insert Recording (scenePhase). url=\(url.absoluteString), duration=\(audioRecorder.timeElapsed))"
-            )
 
-            let recording = Recording(
-                fileURL: url,
-                duration: audioRecorder.timeElapsed
-            )
-
-            modelContext.insert(recording)
-            do {
-                try modelContext.save()
-                logger.log(
-                    "[RecordView] Saved Recording to SwiftData (scenePhase). url=\(url.lastPathComponent), duration=\(recording.duration))"
-                )
-            } catch {
-                logger.log(
-                    "[RecordView] ERROR: Failed to save Recording on scenePhase change. error=\(String(describing: error))"
-                )
-            }
-        } else {
-            logger.log(
-                "[RecordView] ERROR: fileURL is nil after stopRecording() on scenePhase change. Nothing was saved."
-            )
+        guard let url = audioRecorder.fileURL else {
+            logger.log("[RecordView] ERROR: fileURL is nil after stopRecording() on scenePhase change. Nothing was saved.")
+            return
         }
+
+        let recording = Recording(
+            fileURL: url,
+            title: "",
+            isTitleGenerated: false,
+            duration: audioRecorder.timeElapsed
+        )
+        modelContext.insert(recording)
+        do {
+            try modelContext.save()
+            logger.log("[RecordView] Saved Recording to SwiftData (scenePhase). url=\(url.lastPathComponent), duration=\(recording.duration)")
+        } catch {
+            logger.log("[RecordView] ERROR: Failed to save Recording on scenePhase change. error=\(String(describing: error))")
+            return
+        }
+
+        do {
+            _ = try await waitUntilFileReady(url)
+        } catch {
+            let ns = error as NSError
+            logger.log("[RecordView] waitUntilFileReady FAIL: \(ns.domain)(\(ns.code)) \(ns.localizedDescription)")
+        }
+
+        let processor = AudioProcesser() // DI 사용 시 주입 인스턴스로 교체
+        await processor.processAudio(for: recording, modelContext: modelContext)
     }
 
     private func handleRecordButtonTapped() {
@@ -131,7 +135,7 @@ struct RecordView: View {
                     logger.log(
                         "[RecordView] Will insert Recording. url=\(url.absoluteString), duration=\(audioRecorder.timeElapsed))"
                     )
-                    
+
                     // TODO: Location, Weather 넣기
                     let recording = Recording(
                         fileURL: url,
@@ -143,8 +147,22 @@ struct RecordView: View {
                         logger.log(
                             "[RecordView] Saved Recording to SwiftData. url=\(url.lastPathComponent), duration=\(recording.duration))"
                         )
-                        
-                        // TODO: 엘리안 슈퍼 분석 세트 돌리기
+
+                        // 엘리안 슈퍼 분석 세트 돌리기
+                        do {
+                            _ = try await waitUntilFileReady(url)
+                        } catch {
+                            let ns = error as NSError
+                            logger.log(
+                                "[RecordView] waitUntilFileReady FAIL: \(ns.domain)(\(ns.code)) \(ns.localizedDescription)"
+                            )
+                        }
+
+                        let processor = AudioProcesser()
+                        await processor.processAudio(
+                            for: recording,
+                            modelContext: modelContext
+                        )
                     } catch {
                         logger.log(
                             "[RecordView] ERROR: Failed to save Recording. error=\(String(describing: error))"
@@ -183,5 +201,74 @@ struct RecordView: View {
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.dateFormat = "MM월 dd일 HH시 mm분"
         return formatter.string(from: date)
+    }
+
+    private func waitUntilFileReady(
+        _ url: URL,
+        stableWindowMs: Int = 300,  // 사이즈가 이 시간만큼 변하지 않으면 "안정"
+        timeout: TimeInterval = 5.0,  // 최대 대기 시간
+        pollIntervalMs: Int = 100  // 폴링 주기
+    ) async throws -> URL {
+        let fm = FileManager.default
+        let start = Date()
+        var lastSize: UInt64 = 0
+        var lastChange = Date()
+
+        func currentSize() -> UInt64 {
+            guard let attrs = try? fm.attributesOfItem(atPath: url.path),
+                let n = attrs[.size] as? NSNumber
+            else { return 0 }
+            return n.uint64Value
+        }
+
+        while Date().timeIntervalSince(start) < timeout {
+            // 1) 파일 존재 확인
+            guard fm.fileExists(atPath: url.path) else {
+                try? await Task.sleep(
+                    nanoseconds: UInt64(pollIntervalMs) * 1_000_000
+                )
+                continue
+            }
+
+            // 2) 사이즈 안정성 체크
+            let size = currentSize()
+            if size != lastSize {
+                lastSize = size
+                lastChange = Date()
+            }
+
+            let stableFor = Date().timeIntervalSince(lastChange) * 1000
+            let stableEnough = stableFor >= Double(stableWindowMs)
+
+            // 3) AVURLAsset 로딩 가능 여부 확인 (오디오 트랙 로드)
+            if stableEnough && size > 0 {
+                let asset = AVURLAsset(url: url)
+                do {
+                    let tracks = try await asset.load(.tracks)
+                    let hasAudio = tracks.contains { $0.mediaType == .audio }
+                    if hasAudio {
+                        logger.log(
+                            "[waitUntilFileReady] ready url=\(url.lastPathComponent) size=\(size)B"
+                        )
+                        return url
+                    } else {
+                        logger.log(
+                            "[waitUntilFileReady] no audio tracks yet. size=\(size)B"
+                        )
+                    }
+                } catch {
+                    let ns = error as NSError
+                    logger.log(
+                        "[waitUntilFileReady] asset.load(.tracks) error \(ns.domain)(\(ns.code)): \(ns.localizedDescription)"
+                    )
+                }
+            }
+
+            try? await Task.sleep(
+                nanoseconds: UInt64(pollIntervalMs) * 1_000_000
+            )
+        }
+
+        throw APFailure("타임아웃: 파일이 준비되지 않았습니다 (\(url.lastPathComponent))")
     }
 }


### PR DESCRIPTION
## 해결한 이슈 
- #3

## 작업 내용
- 파일변환, 소리분류, 음성전사, 타이틀 생성의 과정을 진행했습니다.
- 타이틀 생성 시, TitleGuide와 TitlePolicy로 파운데이션 모델의 생성형 프롬프트를 관리하고 있습니다.
- TODO에 샤잠킷 넣어야 하는 부위들 추가해두었습니다.

## 하고싶은말
- 추후에 날짜랑 날씨 샤잠킷 들어오면 프롬프팅 쪽 다시 건들 예정입니다