### PR TITLE
feat: 녹음이 끝나면 탭바에서 알림뱃지 달아주기, 검색뷰 분기처리하기, isfavorite 설정하기, 제목편집

### DIFF
--- a/Audiolog/Audiolog/Sources/AudiologView.swift
+++ b/Audiolog/Audiolog/Sources/AudiologView.swift
@@ -20,6 +20,7 @@ struct AudiologView: View {
     @State private var currentTab = "Record"
     @State private var isPresentingPlayerSheet: Bool = false
     @State private var isReprocessingPending = false
+    @State private var isRecordCreated: Bool = false
 
     var body: some View {
         TabView(selection: $currentTab) {
@@ -28,7 +29,7 @@ struct AudiologView: View {
                 systemImage: "microphone",
                 value: "Record"
             ) {
-                RecordView()
+                RecordView(isRecordCreated: $isRecordCreated)
             }
 
             Tab(
@@ -36,8 +37,9 @@ struct AudiologView: View {
                 systemImage: "rectangle.split.2x2.fill",
                 value: "Archive"
             ) {
-                ArchiveView()
+                ArchiveView(isRecordCreated: $isRecordCreated)
             }
+            .badge(isRecordCreated ? Text("N") : nil)
 
             Tab(
                 "Recap",
@@ -97,7 +99,7 @@ struct AudiologView: View {
         }
         logger.log("[AudiologView] Reprocess done.")
     }
-    
+
     private func pendingRecordings() -> [Recording] {
         recordings.filter { !$0.isTitleGenerated || $0.title.isEmpty }
     }

--- a/Audiolog/Audiolog/Sources/Helpers/OrderedSet.swift
+++ b/Audiolog/Audiolog/Sources/Helpers/OrderedSet.swift
@@ -1,0 +1,43 @@
+//
+//  OrderedSet.swift
+//  Audiolog
+//
+//  Created by 성현 on 11/11/25.
+//
+
+import Foundation
+
+struct OrderedSet {
+    private(set) var storage: [String] = []
+    private let caseInsensitive: Bool
+
+    init(_ arr: [String], caseInsensitive: Bool) {
+        self.caseInsensitive = caseInsensitive
+        if caseInsensitive {
+            var seen = Set<String>()
+            for s in arr {
+                let key = s.lowercased()
+                if !seen.contains(key) {
+                    storage.append(s)
+                    seen.insert(key)
+                }
+            }
+        } else {
+            storage = Array(NSOrderedSet(array: arr)) as? [String] ?? arr
+        }
+    }
+
+    mutating func bumpToFront(_ new: String) {
+        let key = caseInsensitive ? new.lowercased() : new
+        storage.removeAll { (caseInsensitive ? $0.lowercased() : $0) == key }
+        storage.insert(new, at: 0)
+    }
+
+    mutating func trim(max: Int) {
+        if storage.count > max { storage = Array(storage.prefix(max)) }
+    }
+
+    func joined(separator: String) -> String {
+        storage.joined(separator: separator)
+    }
+}

--- a/Audiolog/Audiolog/Sources/Views/ArchiveView.swift
+++ b/Audiolog/Audiolog/Sources/Views/ArchiveView.swift
@@ -18,16 +18,36 @@ struct ArchiveView: View {
 
     @Binding var isRecordCreated: Bool
 
+    @State private var editingId: UUID? = nil
+    @State private var tempTitle: String = ""
+    @FocusState private var isEditingFocused: Bool
+
     var body: some View {
         NavigationStack {
             List {
                 ForEach(recordings) { item in
                     HStack(spacing: 12) {
                         VStack(alignment: .leading, spacing: 4) {
-                            Text(item.isTitleGenerated && !item.title.isEmpty ? item.title : "제목 생성중")
+                            if editingId == item.id {
+                                TextField("제목", text: $tempTitle)
+                                    .focused($isEditingFocused)
+                                    .submitLabel(.done)
+                                    .onSubmit {
+                                        commitEdit(for: item)
+                                    }
+                                    .onAppear {
+                                        isEditingFocused = true
+                                    }
+                            } else {
+                                Text(
+                                    item.isTitleGenerated && !item.title.isEmpty
+                                        ? item.title : "제목 생성중"
+                                )
                                 .font(.headline)
                                 .lineLimit(1)
                                 .opacity(item.isTitleGenerated ? 1 : 0.6)
+                            }
+
                             HStack(spacing: 8) {
                                 Text(item.formattedDuration)
                                 Text("·")
@@ -39,42 +59,64 @@ struct ArchiveView: View {
 
                         Spacer()
 
+                        // ⭐️ 즐겨찾기 (VoiceOver 포커스 제외)
                         Button {
-                            item.isFavorite.toggle()
-                            try? modelContext.save()
+                            toggleFavorite(item)
                         } label: {
-                            Image(systemName: item.isFavorite ? "star.fill" : "star")
-                                .imageScale(.large)
-                                .font(.title3)
-                                .padding(.vertical, 6)
-                                .padding(.horizontal, 4)
+                            Image(
+                                systemName: item.isFavorite
+                                    ? "star.fill" : "star"
+                            )
+                            .imageScale(.large)
+                            .font(.title3)
+                            .padding(.vertical, 6)
+                            .padding(.horizontal, 4)
                         }
                         .buttonStyle(.plain)
-                        .accessibilityHidden(true)   // 보이스 오버 포서킹 해제, 예시 코드로 적어두었어요 (추후에 고려해야할 사항)
+                        .accessibilityHidden(true)  // 보이스오버 포커싱 제외
                     }
                     .padding(.vertical, 4)
                     .contentShape(Rectangle())
                     .onTapGesture {
+                        guard editingId == nil else { return }
                         Task { @MainActor in
                             audioPlayer.setPlaylist(recordings)
                             audioPlayer.load(item)
                             audioPlayer.play()
                         }
                     }
-                    .accessibilityElement(children: .combine)
-                    .accessibilityAddTraits(.isButton) // 즐겨찾기를 제외한 행을 버튼으로 포커싱
-                    .swipeActions(edge: .leading, allowsFullSwipe: false) {
+
+                    .swipeActions(edge: .leading, allowsFullSwipe: true) {
                         Button {
-                            item.isFavorite.toggle()
-                            try? modelContext.save()
+                            toggleFavorite(item)
                         } label: {
-                            Label(item.isFavorite ? "해제" : "즐겨찾기",
-                                  systemImage: item.isFavorite ? "star.slash" : "star.fill")
+                            Label(
+                                item.isFavorite ? "해제" : "즐겨찾기",
+                                systemImage: item.isFavorite
+                                    ? "star.slash" : "star.fill"
+                            )
                         }
-                        .tint(item.isFavorite ? .blue : .blue)
+                        .tint(item.isFavorite ? .gray : .yellow)
+                    }
+
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button {
+                            editingId = item.id
+                            tempTitle = item.title
+                        } label: {
+                            Label("수정", systemImage: "pencil")
+                        }
+                        .tint(.blue)
+                        .disabled(editingId != nil)
+
+                        Button(role: .destructive) {
+                            deleteOne(item)
+                        } label: {
+                            Label("삭제", systemImage: "trash")
+                        }
+                        .disabled(editingId != nil)
                     }
                 }
-                .onDelete(perform: delete)
             }
             .listStyle(.insetGrouped)
             .navigationTitle("녹음 목록")
@@ -85,10 +127,49 @@ struct ArchiveView: View {
         }
     }
 
-    private func delete(at offsets: IndexSet) {
-        let items = offsets.map { recordings[$0] }
-        for item in items {
-            modelContext.delete(item)
+//    private func delete(at offsets: IndexSet) {
+//        let items = offsets.map { recordings[$0] }
+//        for item in items {
+//            modelContext.delete(item)
+//        }
+//    }
+
+    private func commitEdit(for item: Recording) {
+        let newTitle = tempTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !newTitle.isEmpty else {
+            // 빈 제목이면 편집 종료만
+            editingId = nil
+            return
+        }
+        item.title = newTitle
+        item.isTitleGenerated = true
+        do {
+            try modelContext.save()
+        } catch {
+            logger.log(
+                "[ArchiveView] title save failed: \(String(describing: error))"
+            )
+        }
+        editingId = nil
+        isEditingFocused = false
+    }
+
+    private func toggleFavorite(_ item: Recording) {
+        item.isFavorite.toggle()
+        do { try modelContext.save() } catch {
+            logger.log(
+                "[ArchiveView] favorite save failed: \(String(describing: error))"
+            )
         }
     }
+
+    private func deleteOne(_ item: Recording) {
+        modelContext.delete(item)
+        do { try modelContext.save() } catch {
+            logger.log(
+                "[ArchiveView] delete save failed: \(String(describing: error))"
+            )
+        }
+    }
+
 }

--- a/Audiolog/Audiolog/Sources/Views/ArchiveView.swift
+++ b/Audiolog/Audiolog/Sources/Views/ArchiveView.swift
@@ -16,6 +16,8 @@ struct ArchiveView: View {
         SortDescriptor<Recording>(\Recording.createdAt, order: .reverse)
     ]) private var recordings: [Recording]
 
+    @Binding var isRecordCreated: Bool
+
     var body: some View {
         NavigationStack {
             List {
@@ -32,10 +34,13 @@ struct ArchiveView: View {
                                 .font(.title2)
                                 .foregroundStyle(.blue)
                             VStack(alignment: .leading, spacing: 4) {
-                                Text(item.isTitleGenerated && !item.title.isEmpty ? item.title : "제목 생성중")
-                                        .font(.headline)
-                                        .lineLimit(1)
-                                        .opacity(item.isTitleGenerated ? 1 : 0.6)
+                                Text(
+                                    item.isTitleGenerated && !item.title.isEmpty
+                                        ? item.title : "제목 생성중"
+                                )
+                                .font(.headline)
+                                .lineLimit(1)
+                                .opacity(item.isTitleGenerated ? 1 : 0.6)
                                 HStack(spacing: 8) {
                                     Text(item.formattedDuration)
                                     Text("·")
@@ -55,6 +60,9 @@ struct ArchiveView: View {
             .listStyle(.insetGrouped)
             .navigationTitle("녹음 목록")
             .navigationBarTitleDisplayMode(.inline)
+        }
+        .onAppear {
+            if isRecordCreated { isRecordCreated = false }
         }
     }
 

--- a/Audiolog/Audiolog/Sources/Views/ArchiveView.swift
+++ b/Audiolog/Audiolog/Sources/Views/ArchiveView.swift
@@ -22,38 +22,57 @@ struct ArchiveView: View {
         NavigationStack {
             List {
                 ForEach(recordings) { item in
-                    Button {
+                    HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(item.isTitleGenerated && !item.title.isEmpty ? item.title : "제목 생성중")
+                                .font(.headline)
+                                .lineLimit(1)
+                                .opacity(item.isTitleGenerated ? 1 : 0.6)
+                            HStack(spacing: 8) {
+                                Text(item.formattedDuration)
+                                Text("·")
+                                Text(item.createdAt, style: .date)
+                            }
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+
+                        Button {
+                            item.isFavorite.toggle()
+                            try? modelContext.save()
+                        } label: {
+                            Image(systemName: item.isFavorite ? "star.fill" : "star")
+                                .imageScale(.large)
+                                .font(.title3)
+                                .padding(.vertical, 6)
+                                .padding(.horizontal, 4)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityHidden(true)   // 보이스 오버 포서킹 해제, 예시 코드로 적어두었어요 (추후에 고려해야할 사항)
+                    }
+                    .padding(.vertical, 4)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
                         Task { @MainActor in
                             audioPlayer.setPlaylist(recordings)
                             audioPlayer.load(item)
                             audioPlayer.play()
                         }
-                    } label: {
-                        HStack(spacing: 12) {
-                            Image(systemName: "waveform.circle.fill")
-                                .font(.title2)
-                                .foregroundStyle(.blue)
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(
-                                    item.isTitleGenerated && !item.title.isEmpty
-                                        ? item.title : "제목 생성중"
-                                )
-                                .font(.headline)
-                                .lineLimit(1)
-                                .opacity(item.isTitleGenerated ? 1 : 0.6)
-                                HStack(spacing: 8) {
-                                    Text(item.formattedDuration)
-                                    Text("·")
-                                    Text(item.createdAt, style: .date)
-                                }
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                        }
-                        .padding(.vertical, 4)
                     }
-                    .buttonStyle(.plain)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityAddTraits(.isButton) // 즐겨찾기를 제외한 행을 버튼으로 포커싱
+                    .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                        Button {
+                            item.isFavorite.toggle()
+                            try? modelContext.save()
+                        } label: {
+                            Label(item.isFavorite ? "해제" : "즐겨찾기",
+                                  systemImage: item.isFavorite ? "star.slash" : "star.fill")
+                        }
+                        .tint(item.isFavorite ? .blue : .blue)
+                    }
                 }
                 .onDelete(perform: delete)
             }

--- a/Audiolog/Audiolog/Sources/Views/RecapView.swift
+++ b/Audiolog/Audiolog/Sources/Views/RecapView.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct RecapView: View {
+    // TODO: Memories 눌렀을 때 조회 가능하게
     private var sampleMemories: [String] {
-        ["2025년 가을", "2025년 여름", "봄 소리", "가을 산책"]
+        ["즐겨찾기", "2025년 여름", "봄 소리", "가을 산책"]
     }
 
     var recapCategoryButtonWidth: CGFloat {

--- a/Audiolog/Audiolog/Sources/Views/RecordView.swift
+++ b/Audiolog/Audiolog/Sources/Views/RecordView.swift
@@ -18,6 +18,7 @@ struct RecordView: View {
     @Environment(\.modelContext) private var modelContext
 
     @State private var showToast: Bool = false
+    @Binding var isRecordCreated: Bool
 
     var body: some View {
         NavigationStack {
@@ -94,6 +95,7 @@ struct RecordView: View {
         modelContext.insert(recording)
         do {
             try modelContext.save()
+            await MainActor.run { isRecordCreated = true }
             logger.log(
                 "[RecordView] Saved Recording to SwiftData (scenePhase). url=\(url.lastPathComponent), duration=\(recording.duration)"
             )
@@ -152,6 +154,7 @@ struct RecordView: View {
                     modelContext.insert(recording)
                     do {
                         try modelContext.save()
+                        await MainActor.run { isRecordCreated = true }
                         logger.log(
                             "[RecordView] Saved Recording to SwiftData. url=\(url.lastPathComponent), duration=\(recording.duration))"
                         )

--- a/Audiolog/Audiolog/Sources/Views/SearchView.swift
+++ b/Audiolog/Audiolog/Sources/Views/SearchView.swift
@@ -8,6 +8,11 @@
 import SwiftData
 import SwiftUI
 
+// AppStorage로 최근 검색 저장, 최대 5개
+private enum RecentSearch {
+    static let data = "RecentSearch"
+}
+
 struct SearchView: View {
     @Environment(AudioPlayer.self) private var audioPlayer
 
@@ -17,6 +22,16 @@ struct SearchView: View {
     ]) private var recordings: [Recording]
 
     @State private var searchText: String = ""
+    @FocusState private var isSearchFocused: Bool
+
+    @AppStorage(RecentSearch.data) private var recentSearch: String = ""
+
+    private var recentItems: [String] {
+        recentSearch
+            .split(separator: "\n")
+            .map { String($0) }
+            .filter { !$0.isEmpty }
+    }
 
     private var filtered: [Recording] {
         let q = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -26,42 +41,105 @@ struct SearchView: View {
 
     var body: some View {
         NavigationStack {
-            List {
-                ForEach(filtered) { item in
-                    Button {
-                        Task { @MainActor in
-                            audioPlayer.load(item)
-                            audioPlayer.play()
-                        }
-                    } label: {
-                        HStack(spacing: 12) {
-                            Image(systemName: "waveform.circle.fill")
-                                .font(.title2)
-                                .foregroundStyle(.blue)
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(item.title)
-                                    .font(.headline)
-                                    .lineLimit(1)
-                                HStack(spacing: 8) {
-                                    Text(item.formattedDuration)
-                                    Text("·")
-                                    Text(item.createdAt, style: .date)
+            if searchText.isEmpty {
+                if isSearchFocused {
+                    Title(text: "최근 검색한 항목_포커스")
+                    Spacer()
+                    if recentItems.isEmpty {
+                        Text("최근 검색한 항목이 없습니다.")
+                    } else {
+
+                        List {
+                            Section {
+                                ForEach(recentItems, id: \.self) { keyword in
+                                    Button {
+                                        searchText = keyword
+                                    } label: {
+                                        HStack {
+                                            Text(keyword)
+                                                .lineLimit(1)
+                                        }
+                                    }
                                 }
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
+                                .onDelete(perform: removeRecent)
                             }
-                            Spacer()
                         }
-                        .padding(.vertical, 4)
+                        .listStyle(.plain)
                     }
-                    .buttonStyle(.plain)
+                } else {
+                    Title(text: "최근 검색한 항목")
+                    Spacer()
+                    if recentItems.isEmpty {
+                        Text("최근 검색한 항목이 없습니다.")
+                    } else {
+                        List {
+                            Section {
+                                ForEach(recentItems, id: \.self) { keyword in
+                                    Button {
+                                        searchText = keyword
+                                    } label: {
+                                        HStack {
+                                            Text(keyword)
+                                                .lineLimit(1)
+                                        }
+                                    }
+                                }
+                                .onDelete(perform: removeRecent)
+                            }
+                        }
+                        .listStyle(.plain)
+                    }
                 }
-                .onDelete(perform: delete)
+            } else {
+                Title(text: "검색 결과")
+
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                    Text("\(filtered.count)개의 항목")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 20)
+                .padding(.trailing, 10)
+                .padding(.vertical, 10)
+
+                List {
+                    ForEach(filtered) { item in
+                        Button {
+                            Task { @MainActor in
+                                saveRecent(searchText)
+                                audioPlayer.load(item)
+                                audioPlayer.play()
+                            }
+                        } label: {
+                            HStack(spacing: 12) {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(item.title)
+                                        .font(.headline)
+                                        .lineLimit(1)
+                                    HStack(spacing: 8) {
+                                        Text(item.formattedDuration)
+                                        Text("·")
+                                        Text(item.createdAt, style: .date)
+                                    }
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                            }
+                            .padding(.vertical, 4)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .onDelete(perform: delete)
+                }
+                .listStyle(.plain)
             }
-            .listStyle(.insetGrouped)
-            .navigationTitle("검색")
         }
         .searchable(text: $searchText, prompt: "Search")
+        .searchFocused($isSearchFocused)
+        .onSubmit(of: .search) {
+            saveRecent(searchText)
+        }
     }
 
     private func delete(at offsets: IndexSet) {
@@ -69,5 +147,26 @@ struct SearchView: View {
         for item in items {
             modelContext.delete(item)
         }
+    }
+
+    private func saveRecent(_ term: String) {
+        let q = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !q.isEmpty else { return }
+
+        var set = OrderedSet(recentItems, caseInsensitive: true)
+        set.bumpToFront(q)
+        set.trim(max: 5)
+
+        recentSearch = set.joined(separator: "\n")
+    }
+
+    private func removeRecent(at offsets: IndexSet) {
+        var arr = recentItems
+        arr.remove(atOffsets: offsets)
+        recentSearch = arr.joined(separator: "\n")
+    }
+
+    private func clearRecent() {
+        recentSearch = ""
     }
 }

--- a/Audiolog/Audiolog/Sources/Views/SearchView.swift
+++ b/Audiolog/Audiolog/Sources/Views/SearchView.swift
@@ -48,7 +48,6 @@ struct SearchView: View {
                     if recentItems.isEmpty {
                         Text("최근 검색한 항목이 없습니다.")
                     } else {
-
                         List {
                             Section {
                                 ForEach(recentItems, id: \.self) { keyword in


### PR DESCRIPTION
## 해결한 이슈 
- #5

## 작업 내용
- 녹음이 끝나면 탭바에서 알림뱃지 달아주기, 검색뷰 분기처리하기, isfavorite 설정하기, 제목편집
- 원래 선택버튼 추가해서 여러개 지울 수 있게 하려고 했는데. 기절할거같아서 일단 스킵하였습니다
- isfavorite는 그 시각장애인분들 보이스오버 포커싱할 때, 탐색에 방해될듯하여 스와이프로만 해당 버튼을 누를 수 있게 해두었습니다.

## 하고싶은말
